### PR TITLE
Update invokeMethod to support namespaces

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4104,6 +4104,10 @@ class nusoap_server extends nusoap_base
             } else {
                 $this->debug("in invoke_method, class=$try_class not found");
             }
+        } elseif (strlen($delim) > 0 && substr_count($this->methodname, $delim) > 1) {
+            $split = explode($delim, $this->methodname);
+            $method = array_pop($split);
+            $class = implode('\\', $split);
         } else {
             $try_class = '';
             $this->debug("in invoke_method, no class to try");


### PR DESCRIPTION
Although this repo is only a PHP 7 compatible fork and the official nusoap seems not to be maintained anymore I've got this small snippet to support namespaces in nusoap methods like register().
Credits for this snippets belongs to the stackoverflow user in this thread: http://stackoverflow.com/questions/30669749/registering-namespaced-php-class-methods-with-nusoap#answer-43096118

I've made this change in the composer installed core file and if this PR might be merged i don't have to bother that my change got overwritten by any update. 

Anyway, thanks for porting to php7 :)