### PR TITLE
Fix "Warning: attempt to modify property of non-object"

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4806,7 +4806,7 @@ class wsdl extends nusoap_base
                     foreach ($xs->imports as $ns2 => $list2) {
                         for ($ii = 0; $ii < count($list2); $ii++) {
                             if (!$list2[$ii]['loaded']) {
-                                $this->schemas[$ns]->imports[$ns2][$ii]['loaded'] = TRUE;
+                                $this->schemas[$ns][$ns2]->imports[$ns2][$ii]['loaded'] = TRUE;
                                 $url = $list2[$ii]['location'];
                                 if ($url != '') {
                                     $urlparts = parse_url($url);


### PR DESCRIPTION
From: [NuSoap version 0.9.5 Attempt to modify property of non-object in nusoap.php](http://www.noaheltzroth.com/nusoap-version-0-9-5-attempt-to-modify-property-of-non-object-in-nusoap-php/):

> I am working with NuSoap and a particular WSDL file was causing the following error for me:
>
> PHP Warning: Attempts to modify property of non-object in lib/nusoap.php on line 4694.
> To fix this problem I modified line 4694 in nusoap.php from:
>
>$this->schemas[$ns]->imports[$ns2][$ii]['loaded'] = true;
>
>To this:
>
> $this->schemas[$ns][$ns2]->imports[$ns2][$ii]['loaded'] = true;
>
> And that fixed the problem.  I found the solution in the NuSoap forums, but I though I would share the information as a post in the hopes it make it easier for someone else to find, and my line number was different than the one mentioned.  It looks like it is an old problem that has not been patched in the official release.