### PR TITLE
Fix false comparison to allow empty SoapAction

### DIFF
--- a/src/nusoap.php
+++ b/src/nusoap.php
@@ -4566,7 +4566,7 @@ class nusoap_server extends nusoap_base
         }
         if (false == $namespace) {
         }
-        if (false == $soapaction) {
+        if (false === $soapaction) {
             if (isset($_SERVER)) {
                 $SERVER_NAME = $_SERVER['SERVER_NAME'];
                 $SCRIPT_NAME = isset($_SERVER['PHP_SELF']) ? $_SERVER['PHP_SELF'] : $_SERVER['SCRIPT_NAME'];


### PR DESCRIPTION
Hi, I needed to set an empty Soap Action registering a method and noticed that when the parameter is an empty string gets overwritten due to a false (default value) comparison.
